### PR TITLE
Fix a few typos from testing analysis code

### DIFF
--- a/jetscape_analysis/analysis/analyze_events_STAT.py
+++ b/jetscape_analysis/analysis/analyze_events_STAT.py
@@ -553,7 +553,7 @@ class AnalyzeJetscapeEvents_STAT(analyze_events_base_STAT.AnalyzeJetscapeEvents_
         elif self.sqrts == 200:
 
             # STAR RAA
-            pt_min = self.inclusive_chjet_observables['pt_star']['pt'][0]
+            pt_min = self.inclusive_chjet_observables['pt_star']['pt_ch'][0]
             pt_max = 100. # Open upper bound
             if jetR in self.inclusive_chjet_observables['pt_star']['jet_R']:
                 if abs(jet.eta()) < (self.inclusive_chjet_observables['pt_star']['eta_cut_R'] - jetR):
@@ -777,6 +777,7 @@ class AnalyzeJetscapeEvents_STAT(analyze_events_base_STAT.AnalyzeJetscapeEvents_
 
         leading_jet = None
         leading_jet_pt = 0.
+        i = 0
         for i,jet in enumerate(jets):
                          
             # Get the corrected jet pt by subtracting the negative recoils within R


### PR DESCRIPTION
I didn't yet test this in the container, but I think this resolves these issues:

200:

```
Traceback (most recent call last):
  File "jetscape_analysis/analysis/analyze_events_STAT.py", line 858, in <module>
    analysis.analyze_jetscape_events()
  File "/usr/local/lib/python3.8/dist-packages/jetscape_analysis/analysis/analyze_events_base_STAT.py", line 76, in analyze_jetscape_events
    self.analyze_event_chunk(df_event_chunk)
  File "/usr/local/lib/python3.8/dist-packages/jetscape_analysis/analysis/analyze_events_base_STAT.py", line 100, in analyze_event_chunk
    self.analyze_event(event)
  File "jetscape_analysis/analysis/analyze_events_STAT.py", line 141, in analyze_event
    [self.analyze_inclusive_jet(jet, fj_hadrons_positive_charged, fj_hadrons_negative_charged, jetR, full_jet=False) for jet in jets_selected_charged]
  File "jetscape_analysis/analysis/analyze_events_STAT.py", line 141, in <listcomp>
    [self.analyze_inclusive_jet(jet, fj_hadrons_positive_charged, fj_hadrons_negative_charged, jetR, full_jet=False) for jet in jets_selected_charged]
  File "jetscape_analysis/analysis/analyze_events_STAT.py", line 333, in analyze_inclusive_jet
    self.fill_charged_jet_ungroomed_histograms(jet, holes_in_jet, jet_pt, jetR)
  File "jetscape_analysis/analysis/analyze_events_STAT.py", line 556, in fill_charged_jet_ungroomed_histograms
    pt_min = self.inclusive_chjet_observables['pt_star']['pt'][0]
KeyError: 'pt'
```

2760:

```
Traceback (most recent call last):
  File "jetscape_analysis/analysis/analyze_events_STAT.py", line 858, in <module>
    analysis.analyze_jetscape_events()
  File "/usr/local/lib/python3.8/dist-packages/jetscape_analysis/analysis/analyze_events_base_STAT.py", line 76, in analyze_jetscape_events
    self.analyze_event_chunk(df_event_chunk)
  File "/usr/local/lib/python3.8/dist-packages/jetscape_analysis/analysis/analyze_events_base_STAT.py", line 100, in analyze_event_chunk
    self.analyze_event(event)
  File "jetscape_analysis/analysis/analyze_events_STAT.py", line 154, in analyze_event
    self.fill_dijet_histograms(jets_selected, fj_hadrons_negative, jetR)
  File "jetscape_analysis/analysis/analyze_events_STAT.py", line 763, in fill_dijet_histograms
    leading_jet, leading_jet_pt, i_leading_jet = self.leading_jet(jet_candidates, fj_hadrons_negative, jetR)
  File "jetscape_analysis/analysis/analyze_events_STAT.py", line 796, in leading_jet
    return leading_jet, leading_jet_pt, i
UnboundLocalError: local variable 'i' referenced before assignment
```

I leave this to @jdmulligan to merge if you're good with the changes